### PR TITLE
remove "rpmforge-release" dependency for centos

### DIFF
--- a/lib/itamae/plugin/recipe/rtn_rbenv/common.rb
+++ b/lib/itamae/plugin/recipe/rtn_rbenv/common.rb
@@ -18,7 +18,6 @@ when %r(debian|ubuntu)
   packages << 'libncurses5-dev'
   packages << 'libffi-dev'
 when %r(redhat|fedora)
-  packages << 'rpmforge-release'
   packages << 'gdbm-devel'
   packages << 'openssl-devel'
   packages << 'libyaml-devel'


### PR DESCRIPTION
"rpmforge-release" dependency causes this error in CentOS-6.6

```
 INFO :          package[gcc]
 INFO :             action: install
 INFO :          package[git]
 INFO :             action: install
 INFO :          package[rpmforge-release]
 INFO :             action: install
 INFO :                installed will change from 'false' to 'true'
ERROR :                   Command `yum -y  install rpmforge-release` failed. (exit status: 1)
ERROR :                   stdout | Loaded plugins: fastestmirror
ERROR :                   stdout | Setting up Install Process
ERROR :                   stdout | Loading mirror speeds from cached hostfile
ERROR :                   stdout |  * base: ftp.iij.ad.jp
ERROR :                   stdout |  * extras: ftp.iij.ad.jp
ERROR :                   stdout |  * updates: ftp.iij.ad.jp
ERROR :                   stdout | No package [1mrpmforge-release(B[m available.
ERROR :                   stdout | Error: Nothing to do
ERROR :          Failed.
```

I use this box.
```
config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box"
```

Is "rpmforge-release" necessary?
Removed this dependency, and passed all tests.
