### PR TITLE
remove including recipe 'rtn_rbenv::user'

### DIFF
--- a/lib/itamae/plugin/recipe/rtn_rbenv.rb
+++ b/lib/itamae/plugin/recipe/rtn_rbenv.rb
@@ -1,3 +1,1 @@
 # encoding: utf-8
-
-include_recipe 'rtn_rbenv::user'


### PR DESCRIPTION
This line causes error when this plugin use as Vagrant plugin.
It is required?

## reference
- http://mactkg.hateblo.jp/entry/2015/02/19/012809 (my blog)
  - https://gist.github.com/gongo/231046cab84389a85a71 (reply for the above entry)