### PR TITLE
Update dependence on itamae version

### DIFF
--- a/itamae-plugin-recipe-rtn_rbenv.gemspec
+++ b/itamae-plugin-recipe-rtn_rbenv.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "itamae", "~> 1.2.4"
+  spec.add_dependency "itamae", "~> 1.3"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Dependence on itamae has been set to `>~ 1.2.4`, so that itamae newer than 1.2.x could not be used.

Tested with 1.6.2 worked fine so I propose to update dependcy.

Thanks,