### PR TITLE
Support specifying profile

### DIFF
--- a/lib/itamae/plugin/recipe/rtn_rbenv/user.rb
+++ b/lib/itamae/plugin/recipe/rtn_rbenv/user.rb
@@ -6,7 +6,8 @@ include_recipe 'rtn_rbenv::common'
 RBENV_USER = (node['rtn_rbenv']['user'] || 'vagrant')
 RBENV_USER_HOME = "/home/#{RBENV_USER}"
 RBENV_ROOT = "#{RBENV_USER_HOME}/.rbenv"
-RBENV_PROFILE_PATH = "#{RBENV_USER_HOME}/.bash_profile"
+RBENV_PROFILE_NAME = (node['rtn_rbenv']['profile'] || '.bash_profile')
+RBENV_PROFILE_PATH = "#{RBENV_USER_HOME}/#{RBENV_PROFILE_NAME}"
 
 # install rbenv and ruby_build
 rbenv_install RBENV_ROOT do


### PR DESCRIPTION
ubuntuでは.bash_profileが読み込まれないので、nodeで指定できるようにしました。
